### PR TITLE
Add zoom level to osrm request

### DIFF
--- a/src/L.Routing.Control.js
+++ b/src/L.Routing.Control.js
@@ -11,6 +11,10 @@
 			waypointMode: 'connect'
 		},
 
+		// used to temporary overide options, e.g. fitSelectedRoutes while dragging
+		_optionsOverride : {
+		},
+
 		initialize: function(options) {
 			L.Util.setOptions(this, options);
 
@@ -35,6 +39,10 @@
 
 			this._map = map;
 			this._map.addLayer(this._plan);
+			this._map.on('zoomend', function() {
+				this._optionsOverride.fitSelectedRoutes = false;
+				this.route();
+			}, this);
 
 			if (this._plan.options.geocoder) {
 				container.insertBefore(this._plan.createGeocoders(), container.firstChild);
@@ -69,26 +77,41 @@
 			return this._plan;
 		},
 
+		_override: function(defaultValue, overrideValue) {
+			if (typeof(overrideValue) !== 'undefined')
+			{
+				return overrideValue;
+			}
+			return defaultValue;
+		},
+
 		_routeSelected: function(e) {
-			var route = e.route;
+			var route = e.route,
+			    fitSelectedRoutes = this._override(this.options.fitSelectedRoutes,
+			                                       this._optionsOverride.fitSelectedRoutes),
+			    waypointMode = this._override(this.options.waypointMode,
+			                                  this._optionsOverride.waypointMode);
 
 			this._clearLine();
 
 			this._line = this.options.routeLine(route,
-				L.extend({extendToWaypoints: this.options.waypointMode === 'connect'},
+				L.extend({extendToWaypoints: waypointMode === 'connect'},
 					this.options.lineOptions));
 			this._line.addTo(this._map);
 			this._hookEvents(this._line);
 
-			if (this.options.fitSelectedRoutes) {
+			if (fitSelectedRoutes) {
 				this._map.fitBounds(this._line.getBounds());
 			}
 
-			if (this.options.waypointMode === 'snap') {
+			if (waypointMode === 'snap') {
 				this._plan.off('waypointschanged', this._onWaypointsChanged, this);
 				this.setWaypoints(route.waypoints);
 				this._plan.on('waypointschanged', this._onWaypointsChanged, this);
 			}
+
+			this._optionsOverride.fitSelectedRoutes = undefined;
+			this._optionsOverride.waypointMode = undefined;
 		},
 
 		_hookEvents: function(l) {
@@ -105,26 +128,20 @@
 		},
 
 		_setupRouteDragging: function() {
-			var lastCalled = 0,
-			    restoreFitSelected,
-			    restoreWpMode;
+			var lastCalled = 0;
 
-			this._plan.on('waypointdragstart', function() {
-				restoreFitSelected = this.options.fitSelectedRoutes;
-				restoreWpMode = this.options.waypointMode;
-				this.options.fitSelectedRoutes = false;
-				this.options.waypointMode = 'connect';
-			}, this);
 			this._plan.on('waypointdrag', L.bind(function(e) {
 				var now = new Date().getTime();
 				if (now - lastCalled >= this.options.routeDragInterval) {
+					this._optionsOverride.fitSelectedRoutes = false;
+					this._optionsOverride.waypointMode = 'connect';
 					this.route({waypoints: e.waypoints, geometryOnly: true});
 					lastCalled = now;
 				}
 			}, this));
 			this._plan.on('waypointdragend', function() {
-				this.options.fitSelectedRoutes = restoreFitSelected;
-				this.options.waypointMode = restoreWpMode;
+				this._optionsOverride.fitSelectedRoutes = undefined;
+				this._optionsOverride.waypointMode = undefined;
 				this.route();
 			}, this);
 		},
@@ -137,6 +154,7 @@
 			this._lastRequestTimestamp = ts;
 
 			if (this._plan.isReady()) {
+				options.z = this._map.getZoom();
 				wps = options && options.waypoints || this._plan.getWaypoints();
 				this.fire('routingstart', {waypoints: wps});
 				this._router.route(wps, function(err, routes) {

--- a/src/L.Routing.OSRM.js
+++ b/src/L.Routing.OSRM.js
@@ -140,6 +140,7 @@
 			return this.options.serviceUrl + '?' +
 				'instructions=' + computeInstructions + '&' +
 				'alt=' + computeAlternative + '&' +
+				(options.z ? 'z=' + options.z + '&' : '') +
 				locs.join('&') +
 				(this._hints.checksum !== undefined ? '&checksum=' + this._hints.checksum : '');
 		},


### PR DESCRIPTION
Adding this parameters has a number of benefits:
1. Returned route geometry will be simplified which saves bandwidth
   (important for longer routes)
2. OSRM will snap the marker to the next non-small connected component.
   Basically that means when you drag a marker on zoomlevel <12,
   OSRM will not snap the marker on a small parking lots, but on the road
   next to it.

To implement this I also had to override the fitSelectedRoutes again,
as we now send a rounting request on each zoom event. I used this
chance to refactor it a little bit.
