### PR TITLE
Alternate lines

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -11,5 +11,13 @@ L.Routing.control({
 	],
 	geocoder: L.Control.Geocoder.nominatim(),
     routeWhileDragging: true,
-    reverseWaypoints: true
+    reverseWaypoints: true,
+    showAlternatives: true,
+    altLineOptions: {
+        styles: [
+            {color: 'black', opacity: 0.15, weight: 9},
+            {color: 'white', opacity: 0.8, weight: 6},
+            {color: 'blue', opacity: 0.5, weight: 2}
+        ]
+    }
 }).addTo(map);

--- a/src/L.Routing.Control.js
+++ b/src/L.Routing.Control.js
@@ -93,12 +93,13 @@
 
 		_routeSelected: function(e) {
 			var route = e.route,
+				alternatives = e.alternatives,
 				fitMode = this.options.fitSelectedRoutes,
 				fitBounds =
 					(fitMode === 'smart' && !this._waypointsVisible()) ||
 					(fitMode !== 'smart' && fitMode);
 
-			this._updateLine(route);
+			this._updateLines({route: route, alternatives: alternatives});
 
 			if (fitBounds) {
 				this._map.fitBounds(this._line.getBounds());
@@ -135,7 +136,7 @@
 				boundsSize = bounds.getSize();
 				return (boundsSize.x > mapSize.x / 5 ||
 					boundsSize.y > mapSize.y / 5) && this._waypointsInViewport();
-					
+
 			} catch (e) {
 				return false;
 			}
@@ -161,12 +162,23 @@
 			return false;
 		},
 
-		_updateLine: function(route) {
+		_updateLines: function(routes) {
 			var addWaypoints = this.options.addWaypoints !== undefined ?
 				this.options.addWaypoints : true;
-			this._clearLine();
+			this._clearLines();
 
-			this._line = this.options.routeLine(route,
+			// add alternatives first so they lie below the main route
+			this._alternatives = [];
+			if (routes.alternatives) routes.alternatives.forEach(function(alt, i) {
+				this._alternatives[i] = this.options.routeLine(alt,
+					L.extend({
+						isAlternative: true
+					}, this.options.altLineOptions));
+				this._alternatives[i].addTo(this._map);
+				this._hookAltEvents(this._alternatives[i]);
+			}, this);
+
+			this._line = this.options.routeLine(routes.route,
 				L.extend({
 					addWaypoints: addWaypoints,
 					extendToWaypoints: this.options.waypointMode === 'connect'
@@ -181,12 +193,20 @@
 			}, this);
 		},
 
+		_hookAltEvents: function(l) {
+			l.on('linetouched', function(e) {
+				var alts = this._routes.slice();
+				var selected = alts.splice(e.target._route.routesIndex, 1)[0];
+				this._routeSelected({route: selected, alternatives: alts});
+			}, this);
+		},
+
 		_onWaypointsChanged: function(e) {
 			if (this.options.autoRoute) {
 				this.route({});
 			}
 			if (!this._plan.isReady()) {
-				this._clearLine();
+				this._clearLines();
 				this._clearAlts();
 			}
 			this.fire('waypointschanged', {waypoints: e.waypoints});
@@ -221,7 +241,7 @@
 
 		_updateLineCallback: function(err, routes) {
 			if (!err) {
-				this._updateLine(routes[0]);
+				this._updateLines({route: routes[0], alternatives: routes.slice(1) });
 			}
 		},
 
@@ -244,28 +264,37 @@
 					// against the last request's; ignore result if
 					// this isn't the latest request.
 					if (ts === this._requestCount) {
-						this._clearLine();
+						this._clearLines();
 						this._clearAlts();
 						if (err) {
 							this.fire('routingerror', {error: err});
 							return;
 						}
 
+						routes.forEach(function(route, i) { route.routesIndex = i; });
+
 						if (!options.geometryOnly) {
 							this.fire('routesfound', {waypoints: wps, routes: routes});
 							this.setAlternatives(routes);
 						} else {
-							this._routeSelected({route: routes[0]});
+							var selectedRoute = routes.splice(0,1)[0];
+							this._routeSelected({route: selectedRoute, alternatives: routes});
 						}
 					}
 				}, this, options);
 			}
 		},
 
-		_clearLine: function() {
+		_clearLines: function() {
 			if (this._line) {
 				this._map.removeLayer(this._line);
 				delete this._line;
+			}
+			if (this._alternatives && this._alternatives.length) {
+				for (var i in this._alternatives) {
+					this._map.removeLayer(this._alternatives[i]);
+				}
+				this._alternatives = [];
 			}
 		}
 	});

--- a/src/L.Routing.Control.js
+++ b/src/L.Routing.Control.js
@@ -30,7 +30,6 @@
 
 			L.Routing.Itinerary.prototype.initialize.call(this, options);
 
-			this.on('dispatchroutes', this._dispatchRoutes, this);
 			this.on('routeselected', this._routeSelected, this);
 			this._plan.on('waypointschanged', this._onWaypointsChanged, this);
 			if (options.routeWhileDragging) {
@@ -199,7 +198,7 @@
 			l.on('linetouched', function(e) {
 				var alts = this._routes.slice();
 				var selected = alts.splice(e.target._route.routesIndex, 1)[0];
-				this.fire('dispatchroutes', {route: selected, alternatives: alts});
+				this.fire('routeselected', {route: selected, alternatives: alts});
 			}, this);
 		},
 

--- a/src/L.Routing.Control.js
+++ b/src/L.Routing.Control.js
@@ -29,6 +29,7 @@
 
 			L.Routing.Itinerary.prototype.initialize.call(this, options);
 
+			this.on('dispatchroutes', this._dispatchRoutes, this);
 			this.on('routeselected', this._routeSelected, this);
 			this._plan.on('waypointschanged', this._onWaypointsChanged, this);
 			if (options.routeWhileDragging) {
@@ -197,8 +198,7 @@
 			l.on('linetouched', function(e) {
 				var alts = this._routes.slice();
 				var selected = alts.splice(e.target._route.routesIndex, 1)[0];
-				this._routeSelected({route: selected, alternatives: alts});
-				this.fire('alternateChosen', {routesIndex: e.target._route.routesIndex});
+				this.fire('dispatchroutes', {route: selected, alternatives: alts});
 			}, this);
 		},
 

--- a/src/L.Routing.Control.js
+++ b/src/L.Routing.Control.js
@@ -94,7 +94,7 @@
 
 		_routeSelected: function(e) {
 			var route = e.route,
-				alternatives = e.alternatives,
+				alternatives = this.options.showAlternatives && e.alternatives,
 				fitMode = this.options.fitSelectedRoutes,
 				fitBounds =
 					(fitMode === 'smart' && !this._waypointsVisible()) ||

--- a/src/L.Routing.Control.js
+++ b/src/L.Routing.Control.js
@@ -17,7 +17,8 @@
 			routeWhileDragging: false,
 			routeDragInterval: 500,
 			waypointMode: 'connect',
-			useZoomParameter: false
+			useZoomParameter: false,
+			showAlternatives: false
 		},
 
 		initialize: function(options) {
@@ -174,7 +175,7 @@
 				this._alternatives[i] = this.options.routeLine(alt,
 					L.extend({
 						isAlternative: true
-					}, this.options.altLineOptions));
+					}, this.options.altLineOptions || this.options.lineOptions));
 				this._alternatives[i].addTo(this._map);
 				this._hookAltEvents(this._alternatives[i]);
 			}, this);

--- a/src/L.Routing.Control.js
+++ b/src/L.Routing.Control.js
@@ -198,6 +198,7 @@
 				var alts = this._routes.slice();
 				var selected = alts.splice(e.target._route.routesIndex, 1)[0];
 				this._routeSelected({route: selected, alternatives: alts});
+				this.fire('alternateChosen', {routesIndex: e.target._route.routesIndex});
 			}, this);
 		},
 

--- a/src/L.Routing.Itinerary.js
+++ b/src/L.Routing.Itinerary.js
@@ -89,7 +89,7 @@
 				this._altElements.push(altDiv);
 			}
 
-			this._selectRoute(this._routes[0]);
+			this._selectRoute({route: this._routes[0], alternatives: this._routes.slice(1)});
 
 			return this;
 		},
@@ -199,8 +199,10 @@
 					}
 
 					if (isCurrentSelection) {
+						var alts = this._routes.slice();
+						alts.splice(j,1);
 						// TODO: don't fire if the currently active is clicked
-						this._selectRoute(this._routes[j]);
+						this._selectRoute({route: this._routes[j], alternatives: alts});
 					} else {
 						n.scrollTop = 0;
 					}
@@ -210,12 +212,12 @@
 			L.DomEvent.stop(e);
 		},
 
-		_selectRoute: function(route) {
+		_selectRoute: function(routes) {
 			if (this._marker) {
 				this._map.removeLayer(this._marker);
 				delete this._marker;
 			}
-			this.fire('routeselected', {route: route});
+			this.fire('routeselected', routes);
 		}
 	});
 

--- a/src/L.Routing.Itinerary.js
+++ b/src/L.Routing.Itinerary.js
@@ -184,7 +184,7 @@
 			    isCurrentSelection,
 			    classFn;
 
-			altElem = e.routesIndex ? this._altElements[e.routesIndex] : e.target || window.event.srcElement;
+			altElem = !isNaN(e.routesIndex) ? this._altElements[e.routesIndex] : e.target || window.event.srcElement;
 			while (!L.DomUtil.hasClass(altElem, 'leaflet-routing-alt')) {
 				altElem = altElem.parentElement;
 			}
@@ -199,7 +199,7 @@
 						L.DomUtil[classFn](n, this.options.minimizedClassName);
 					}
 
-					if (!e.routesIndex) {
+					if (isNaN(e.routesIndex)) {
 						if (isCurrentSelection) {
 							var alts = this._routes.slice();
 							alts.splice(j,1);

--- a/src/L.Routing.Itinerary.js
+++ b/src/L.Routing.Itinerary.js
@@ -107,10 +107,6 @@
 			this[collapsed ? 'show' : 'hide']();
 		},
 
-		_dispatchRoutes: function(e) {
-			this.fire('routeselected', e);
-		},
-
 		_createAlternative: function(alt, i) {
 			var altDiv = L.DomUtil.create('div', 'leaflet-routing-alt ' +
 				this.options.alternativeClassName +
@@ -190,7 +186,7 @@
 			var alts = this._routes.slice();
 			var route = alts.splice(j, 1)[0];
 
-			this.fire('dispatchroutes', {
+			this.fire('routeselected', {
 				route: route,
 				alternatives: alts
 			});

--- a/src/L.Routing.Itinerary.js
+++ b/src/L.Routing.Itinerary.js
@@ -119,6 +119,7 @@
 				}, alt);
 			altDiv.innerHTML = typeof(template) === 'function' ? template(data) : L.Util.template(template, data);
 			L.DomEvent.addListener(altDiv, 'click', this._onAltClicked, this);
+			this.on('alternateChosen', this._onAltClicked, this);
 
 			altDiv.appendChild(this._createItineraryContainer(alt));
 			return altDiv;
@@ -183,7 +184,7 @@
 			    isCurrentSelection,
 			    classFn;
 
-			altElem = e.target || window.event.srcElement;
+			altElem = e.routesIndex ? this._altElements[e.routesIndex] : e.target || window.event.srcElement;
 			while (!L.DomUtil.hasClass(altElem, 'leaflet-routing-alt')) {
 				altElem = altElem.parentElement;
 			}
@@ -198,13 +199,14 @@
 						L.DomUtil[classFn](n, this.options.minimizedClassName);
 					}
 
-					if (isCurrentSelection) {
-						var alts = this._routes.slice();
-						alts.splice(j,1);
-						// TODO: don't fire if the currently active is clicked
-						this._selectRoute({route: this._routes[j], alternatives: alts});
-					} else {
-						n.scrollTop = 0;
+					if (!e.routesIndex) {
+						if (isCurrentSelection) {
+							var alts = this._routes.slice();
+							alts.splice(j,1);
+							this._selectRoute({route: this._routes[j], alternatives: alts});
+						} else {
+							n.scrollTop = 0;
+						}
 					}
 				}
 			}

--- a/src/L.Routing.Itinerary.js
+++ b/src/L.Routing.Itinerary.js
@@ -32,7 +32,8 @@
 				L.DomEvent.on(collapseBtn, 'click', itinerary._toggle, itinerary);
 				itinerary._container.insertBefore(collapseBtn, itinerary._container.firstChild);
 			},
-			collapseBtnClass: 'leaflet-routing-collapse-btn'
+			collapseBtnClass: 'leaflet-routing-collapse-btn',
+			showAlternatives: false
 		},
 
 		initialize: function(options) {

--- a/src/L.Routing.Itinerary.js
+++ b/src/L.Routing.Itinerary.js
@@ -32,8 +32,7 @@
 				L.DomEvent.on(collapseBtn, 'click', itinerary._toggle, itinerary);
 				itinerary._container.insertBefore(collapseBtn, itinerary._container.firstChild);
 			},
-			collapseBtnClass: 'leaflet-routing-collapse-btn',
-			showAlternatives: false
+			collapseBtnClass: 'leaflet-routing-collapse-btn'
 		},
 
 		initialize: function(options) {

--- a/src/L.Routing.OSRM.js
+++ b/src/L.Routing.OSRM.js
@@ -192,8 +192,8 @@
 				!(options && options.geometryOnly);
 
 			return this.options.serviceUrl + '?' +
-				'instructions=' + computeInstructions + '&' +
-				'alt=' + computeAlternative + '&' +
+				'instructions=' + computeInstructions.toString() + '&' +
+				'alt=' + computeAlternative.toString() + '&' +
 				(options.z ? 'z=' + options.z + '&' : '') +
 				locs.join('&') +
 				(this._hints.checksum !== undefined ? '&checksum=' + this._hints.checksum : '') +


### PR DESCRIPTION
This PR adds an option to `L.Routing.Control` to allow for displaying alternate routes as polylines where available, where `showAlternatives` is a boolean (defaults to `false`) and `altLineOptions` mirrors `lineOptions` to style alternate line(s). Alternative lines are clickable to switch focus to that route (which also changes the itinerary display to indicate that the clicked line is chosen). (We want to use this in the osrm-frontend rewrite.) In practice that looks like this:

![lrm-altlineoptions](https://cloud.githubusercontent.com/assets/3170312/9459538/7ea26ce4-4ab1-11e5-8d47-a134f752874b.gif)

@perliedman — if this looks good to you I'll go ahead and add any necessary docs/tests.