### PR TITLE
provide correct context for reversegeocoded event

### DIFF
--- a/src/L.Routing.Plan.js
+++ b/src/L.Routing.Plan.js
@@ -161,7 +161,7 @@
 					waypointIndex: i,
 					waypoint: e.waypoint
 				});
-			});
+			}, this);
 
 			return geocoder;
 		},


### PR DESCRIPTION
This makes `reversegeocoded` actually fire `waypointgeocoded` as intended.