### PR TITLE
Add Grunt/Wiredep Support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,13 @@
     "route"
   ],
   "license": "MIT",
+	"main": [
+  	"dist/leaflet.routing.icons.png",
+  	"dist/leaflet-routing-machine.css",
+  	"dist/leaflet.routing.icons.svg",
+  	"dist/leaflet-routing-machine.js",
+  	"dist/routing-icon.png"
+  ],
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
Small Extension to bower.json that allows to use it with wiredep. e.g. `bower install --save leaflet-routing-maching ; grunt wiredep` 