### PR TITLE
fix geocoderClass

### DIFF
--- a/src/L.Routing.GeocoderElement.js
+++ b/src/L.Routing.GeocoderElement.js
@@ -64,7 +64,7 @@
 				closeButton = g.closeButton,
 				geocoderInput = g.input;
 			geocoderInput.setAttribute('placeholder', this.options.geocoderPlaceholder(i, nWps, this));
-			geocoderInput.className = this.options.geocoderClass(i, nWps);
+			geocoderInput.className = this.options.geocoderClass;
 
 			this._element = g;
 			this._waypoint = wp;


### PR DESCRIPTION
geocoderClass must be string, not function, as described in doc API http://www.liedman.net/leaflet-routing-machine/api/#l-routing-plan
Or docs incorrect?