### PR TITLE
add title and extension to license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+## ISC License
+
 Copyright (c) 2014, Per Liedman (per@liedman.net)
 Turn instruction icons Copyright (c) 2014, Mapbox (mapbox.com)
 


### PR DESCRIPTION
The title is not strictly required, but it's useful metadata, and part of the recommended license template text (see http://choosealicense.com/licenses/isc/ and https://opensource.org/licenses/isc-license)

The extension helps with the display of the license on github (it activates text wrapping)