### PR TITLE
WIP: Add option for custom osrm stepToText

### DIFF
--- a/src/L.Routing.OSRMv1.js
+++ b/src/L.Routing.OSRMv1.js
@@ -166,7 +166,8 @@
 				step,
 				geometry,
 				type,
-				modifier;
+				modifier,
+				text;
 
 			for (i = 0; i < legCount; i++) {
 				leg = responseRoute.legs[i];
@@ -177,6 +178,7 @@
 					result.coordinates.push.apply(result.coordinates, geometry);
 					type = this._maneuverToInstructionType(step.maneuver, i === legCount - 1);
 					modifier = this._maneuverToModifier(step.maneuver);
+					text = this._stepToText(step);
 
 					if (type) {
 						result.instructions.push({
@@ -188,7 +190,8 @@
 							exit: step.maneuver.exit,
 							index: index,
 							mode: step.mode,
-							modifier: modifier
+							modifier: modifier,
+							text: text
 						});
 					}
 
@@ -202,6 +205,17 @@
 			}
 
 			return result;
+		},
+
+		_stepToText: function(step) {
+			if (options.stepToText) {
+				// use custom text instruction generation
+				// if provided
+				return options.stepToText(step);
+			} else {
+				// by default delegate text instruction generation
+				// to generic downstream implementation
+				return undefined;
 		},
 
 		_bearingToDirection: function(bearing) {


### PR DESCRIPTION
Context https://github.com/Project-OSRM/osrm-frontend/pull/187

With https://github.com/Project-OSRM/osrm-text-instructions.js we are working on an external solution for _osrm step objects_ to _text instructions_. The reasons why this should not directly live in leaflet-routing-machine:
- The text instruction generation code should be portable between languages, not JS only
- The text instruction generation code should be changeable by the user. We are thinking translations, but also different tastes of how each instructions should be phrased (`Make a left` vs `Turn left` vs `Do a left turn`)

In https://github.com/Project-OSRM/osrm-frontend/pull/187 I went quite out-of-my way to monkey-patch the custom text generation into LRM. It feels brittle, and instead would be nicer to be supported within LRM.

In this PR is one solution. I did not actually hook this up yet to test if it works with `options`.

@perliedman what do you think about this?

Next:
- [ ] Decide on design
- [ ] @freenerd to make this actually work
- [ ] Tests?
- [ ] 🎉 
