### PR TITLE
OSRM 5. reversed lat/lng values

### DIFF
--- a/src/L.Routing.OSRMv1.js
+++ b/src/L.Routing.OSRMv1.js
@@ -278,7 +278,7 @@
 			var wps = [],
 			    i;
 			for (i = 0; i < vias.length; i++) {
-				wps.push(L.Routing.waypoint(L.latLng(vias[i].location),
+				wps.push(L.Routing.waypoint(L.latLng({lat: vias[i].location[1], lng: vias[i].location[0]}),
 				                            inputWaypoints[i].name,
 											inputWaypoints[i].options));
 			}


### PR DESCRIPTION
Fix for OSRM v5 that uses `[lng, lat]` order in compare to v4, that uses `[lat, lng]`