### PR TITLE
delete alternative routes when the control is removed

### DIFF
--- a/src/L.Routing.Control.js
+++ b/src/L.Routing.Control.js
@@ -92,6 +92,11 @@
 				map.removeLayer(this._line);
 			}
 			map.removeLayer(this._plan);
+			if (this._alternatives && this._alternatives.length >0) {
+				this._alternatives.forEach(function(alt, i) {
+					map.removeLayer(this._alternatives[i]);				
+				}, this);
+			}
 			return L.Routing.Itinerary.prototype.onRemove.call(this, map);
 		},
 


### PR DESCRIPTION
when the control is removed from a map, the alternatives routes doesn't delete.  