### PR TITLE
Updated serviceUrl of Nomatim

### DIFF
--- a/examples/Control.Geocoder.js
+++ b/examples/Control.Geocoder.js
@@ -309,7 +309,7 @@
 
 	L.Control.Geocoder.Nominatim = L.Class.extend({
 		options: {
-			serviceUrl: '//nominatim.openstreetmap.org/',
+			serviceUrl: 'http://nominatim.openstreetmap.org/',
 			geocodingQueryParams: {},
 			reverseQueryParams: {},
 			htmlTemplate: function(r) {


### PR DESCRIPTION
ServiceUrl now follows Nominatim wiki "http://nominatim.openstreetmap.org/search"