### PR TITLE
Add leaflet as a dependency, change package main to unbundled javascript.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "uglify-js": "^2.7.5"
   },
   "dependencies": {
+    "leaflet": "^1.0.2",
     "osrm-text-instructions": "^0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "browserify-shim": {
     "leaflet": "global:L"
   },
-  "main": "./dist/leaflet-routing-machine.js",
+  "main": "src/leaflet-routing-machine.js",
   "devDependencies": {
     "browserify": "^13.1.1",
     "browserify-derequire": "^0.9.4",


### PR DESCRIPTION
This is a more standard way to handle dependencies in NPM modules, and it works better with bundlers like webpack.