### PR TITLE
Changed "main" in package.json to point to src instead of dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "browserify-shim": {
     "leaflet": "global:L"
   },
-  "main": "./dist/leaflet-routing-machine.js",
+  "main": "./src/leaflet-routing-machine.js",
   "devDependencies": {
     "browserify": "^13.1.1",
     "browserify-derequire": "^0.9.4",


### PR DESCRIPTION
This is the solution to webpack complaining about prebundled code.
Users will have to have leaflet installed apart from the plugin.  But because it's a plugin, that is assumed.

This is how other plugins seem to manage it.  I don't see any downsides.