### PR TITLE
moved corslite, polyline to dependencies, added namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "browserify": "^14.1.0",
     "browserify-derequire": "^0.9.4",
     "browserify-shim": "^3.8.13",
-    "corslite": "0.0.7",
     "derequire": "^2.0.6",
-    "polyline": "0.2.0",
     "uglify-js": "^2.8.2"
   },
   "dependencies": {
+    "@mapbox/corslite": "0.0.7",
+    "@mapbox/polyline": "^0.2.0",
     "osrm-text-instructions": "^0.1.0"
   }
 }

--- a/src/osrm-v1.js
+++ b/src/osrm-v1.js
@@ -2,8 +2,8 @@
 	'use strict';
 
 	var L = require('leaflet'),
-		corslite = require('corslite'),
-		polyline = require('polyline'),
+		corslite = require('@mapbox/corslite'),
+		polyline = require('@mapbox/polyline'),
 		osrmTextInstructions = require('osrm-text-instructions');
 
 	// Ignore camelcase naming for this file, since OSRM's API uses


### PR DESCRIPTION
- I suggest moving `corslite` and `polyline` to `dependencies` here. I am bundling the part of Leaflet Routing Machine from the source. I noticed building process breaks because it can't find `corslite`and `polyline`. 
- I also added namespace (`@mapbox`) for each of package. 

Thanks for all the good works! 