### PR TITLE
add property for mapbox annotation fields

### DIFF
--- a/src/osrm-v1.js
+++ b/src/osrm-v1.js
@@ -171,7 +171,8 @@
 					summary: {
 						totalDistance: responseRoute.distance,
 						totalTime: responseRoute.duration
-					}
+					},
+					annotation: []
 				},
 				legNames = [],
 				waypointIndices = [],
@@ -198,6 +199,9 @@
 			for (i = 0; i < legCount; i++) {
 				leg = responseRoute.legs[i];
 				legNames.push(leg.summary && leg.summary.charAt(0).toUpperCase() + leg.summary.substring(1));
+				if (typeof leg.annotation !== 'undefined') {
+                    result.annotation.push(leg.annotation);
+                }
 				for (j = 0; j < leg.steps.length; j++) {
 					step = leg.steps[j];
 					geometry = this._decodePolyline(step.geometry);

--- a/src/osrm-v1.js
+++ b/src/osrm-v1.js
@@ -199,7 +199,7 @@
 			for (i = 0; i < legCount; i++) {
 				leg = responseRoute.legs[i];
 				legNames.push(leg.summary && leg.summary.charAt(0).toUpperCase() + leg.summary.substring(1));
-				if (typeof leg.annotation !== 'undefined') {
+                if (typeof leg.annotation !== 'undefined') {
                     result.annotation.push(leg.annotation);
                 }
 				for (j = 0; j < leg.steps.length; j++) {


### PR DESCRIPTION
Using requestParameters with Mapbox makes possible to request additional leg info as annotations fields, but result route object has no property for storing them and they are losted inside _convertRoute(). I add a property for annotations so they can be accessed like route.annotation from route object.

For requesting annotations from Mapbox use requestParameters like this:
requestParameters: {
    annotations: "duration,distance,speed"                    
}