### PR TITLE
fix the styles problem in routing

### DIFF
--- a/src/control.js
+++ b/src/control.js
@@ -301,6 +301,7 @@
 				this._pendingRequest = this._router.route(wps, function(err, routes) {
 					this._pendingRequest = null;
 
+					routes.forEach(function(route, i) { route.routesIndex = i; });
 					if (options.callback) {
 						return options.callback.call(this, err, routes);
 					}
@@ -317,7 +318,7 @@
 							return;
 						}
 
-						routes.forEach(function(route, i) { route.routesIndex = i; });
+			
 
 						if (!options.geometryOnly) {
 							this.fire('routesfound', {waypoints: wps, routes: routes});

--- a/src/line.js
+++ b/src/line.js
@@ -30,7 +30,8 @@
 			if (this.options.extendToWaypoints) {
 				this._extendToWaypoints();
 			}
-
+			var styleArray=[];
+			styleArray.push(this.options.styles[route.routesIndex]);
 			this._addSegment(
 				route.coordinates,
 				this.options.styles,


### PR DESCRIPTION
first commit
when I was using of routing, I realized if I add some styles and have some routes, all routes have the last style I was defined in style list, so I set styles on routes based on their route index,

second commit:
when I changed the first commit, I came to know when I zoom on the map, my routes are changing to default style because in zoom event route object didn't have RouteIndex property, so in this commit, I added RouteIndex to route Objects in all events