### PR TITLE
Remove deprecation warnings due to including L.Mixin.Events

### DIFF
--- a/src/geocoder-element.js
+++ b/src/geocoder-element.js
@@ -16,7 +16,7 @@
 	}
 
 	module.exports = L.Class.extend({
-		includes: (L.Evented.prototype || L.Mixin.Events),
+		includes: ((typeof L.Evented !== 'undefined' && L.Evented.prototype) || L.Mixin.Events),
 
 		options: {
 			createGeocoder: function(i, nWps, options) {

--- a/src/geocoder-element.js
+++ b/src/geocoder-element.js
@@ -16,7 +16,7 @@
 	}
 
 	module.exports = L.Class.extend({
-		includes: L.Mixin.Events,
+		includes: (L.Evented.prototype || L.Mixin.Events),
 
 		options: {
 			createGeocoder: function(i, nWps, options) {

--- a/src/itinerary.js
+++ b/src/itinerary.js
@@ -6,7 +6,7 @@
 	var ItineraryBuilder = require('./itinerary-builder');
 
 	module.exports = L.Control.extend({
-		includes: L.Mixin.Events,
+		includes: (L.Evented.prototype || L.Mixin.Events),
 
 		options: {
 			pointMarkerStyle: {

--- a/src/itinerary.js
+++ b/src/itinerary.js
@@ -6,7 +6,7 @@
 	var ItineraryBuilder = require('./itinerary-builder');
 
 	module.exports = L.Control.extend({
-		includes: (L.Evented.prototype || L.Mixin.Events),
+		includes: ((typeof L.Evented !== 'undefined' && L.Evented.prototype) || L.Mixin.Events),
 
 		options: {
 			pointMarkerStyle: {

--- a/src/line.js
+++ b/src/line.js
@@ -4,7 +4,7 @@
 	var L = require('leaflet');
 
 	module.exports = L.LayerGroup.extend({
-		includes: (L.Evented.prototype || L.Mixin.Events),
+		includes: ((typeof L.Evented !== 'undefined' && L.Evented.prototype) || L.Mixin.Events),
 
 		options: {
 			styles: [

--- a/src/line.js
+++ b/src/line.js
@@ -2,9 +2,9 @@
 	'use strict';
 
 	var L = require('leaflet');
-	
+
 	module.exports = L.LayerGroup.extend({
-		includes: L.Mixin.Events,
+		includes: (L.Evented.prototype || L.Mixin.Events),
 
 		options: {
 			styles: [
@@ -36,7 +36,7 @@
 				this.options.styles,
 				this.options.addWaypoints);
 		},
-		
+
 		getBounds: function() {
 			return L.latLngBounds(this._route.coordinates);
 		},

--- a/src/plan.js
+++ b/src/plan.js
@@ -6,7 +6,7 @@
 	var Waypoint = require('./waypoint');
 
 	module.exports = (L.Layer || L.Class).extend({
-		includes: (L.Evented.prototype || L.Mixin.Events),
+		includes: ((typeof L.Evented !== 'undefined' && L.Evented.prototype) || L.Mixin.Events),
 
 		options: {
 			dragStyles: [

--- a/src/plan.js
+++ b/src/plan.js
@@ -6,7 +6,7 @@
 	var Waypoint = require('./waypoint');
 
 	module.exports = (L.Layer || L.Class).extend({
-		includes: L.Mixin.Events,
+		includes: (L.Evented.prototype || L.Mixin.Events),
 
 		options: {
 			dragStyles: [


### PR DESCRIPTION
As the routing machine includes Events in four places, the javascript console produces four deprecation warnings

https://github.com/perliedman/leaflet-routing-machine/issues/425