### PR TITLE
upgrade leaflet in example to 1.2.0

### DIFF
--- a/tutorials/basic-usage/index.html
+++ b/tutorials/basic-usage/index.html
@@ -48,7 +48,7 @@ title: Basics tutorial
 &lt;head&gt;
     &lt;meta charset=&quot;utf-8&quot; /&gt;
     &lt;title&gt;Leaflet Routing Machine Example&lt;/title&gt;
-    &lt;link rel=&quot;stylesheet&quot; href=&quot;http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css&quot; /&gt;
+    &lt;link rel=&quot;stylesheet&quot; href=&quot;https://unpkg.com/leaflet@1.2.0/dist/leaflet.css&quot; /&gt;
     &lt;link rel=&quot;stylesheet&quot; href=&quot;leaflet-routing-machine.css&quot; /&gt;
     &lt;style&gt;
         .map {
@@ -60,7 +60,7 @@ title: Basics tutorial
 &lt;/head&gt;
 &lt;body&gt;
     &lt;div id=&quot;map&quot; class=&quot;map&quot;&gt;&lt;/div&gt;
-    &lt;script src=&quot;http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js&quot;&gt;&lt;/script&gt;
+    &lt;script src=&quot;https://unpkg.com/leaflet@1.2.0/dist/leaflet.js&quot;&gt;&lt;/script&gt;
     &lt;script src=&quot;leaflet-routing-machine.js&quot;&gt;&lt;/script&gt;
 &lt;/body&gt;
 &lt;/html&gt;</code></pre>


### PR DESCRIPTION
As reported in #444, lrm is broken with old Leaflet versions, so this change updates the examples provided to use a more recent Leaflet.