### PR TITLE
Read the global configuration, not the local one

### DIFF
--- a/src/control.js
+++ b/src/control.js
@@ -319,7 +319,7 @@
 
 						routes.forEach(function(route, i) { route.routesIndex = i; });
 
-						if (!options.geometryOnly) {
+						if (!this.options.geometryOnly) {
 							this.fire('routesfound', {waypoints: wps, routes: routes});
 							this.setAlternatives(routes);
 						} else {


### PR DESCRIPTION
Local `options` contains the waypoint list, but `geometryOnly` is in the global `options` object