### PR TITLE
Enable customization of geocoder result HTML

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -74,7 +74,13 @@
 				tr = L.DomUtil.create('tr', '', this._resultTable);
 				tr.setAttribute('data-result-index', i);
 				td = L.DomUtil.create('td', '', tr);
-				text = document.createTextNode(results[i].name);
+
+				if (this._geocoderResult) {
+					text = this._geocoderResult(results[i]);
+				} else {
+					text = document.createTextNode(results[i].name);
+				}
+
 				td.appendChild(text);
 				// mousedown + click because:
 				// http://stackoverflow.com/questions/10652852/jquery-fire-click-before-blur-event

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -75,8 +75,8 @@
 				tr.setAttribute('data-result-index', i);
 				td = L.DomUtil.create('td', '', tr);
 
-				if (this._geocoderResult) {
-					text = this._geocoderResult(results[i]);
+				if (this.options.formatGeocoderResult) {
+					text = this.options.formatGeocoderResult(results[i]);
 				} else {
 					text = document.createTextNode(results[i].name);
 				}

--- a/src/geocoder-element.js
+++ b/src/geocoder-element.js
@@ -85,8 +85,8 @@
 				}, this);
 			}
 
-			if (typeof this.options.geocoderResult == 'function') {
-				this.options.autocompleteOptions.geocoderResult = this.options.geocoderResult;
+			if (typeof this.options.formatGeocoderResult == 'function') {
+				this.options.autocompleteOptions.formatGeocoderResult = this.options.formatGeocoderResult;
 			}
 
 			new Autocomplete(geocoderInput, function(r) {

--- a/src/geocoder-element.js
+++ b/src/geocoder-element.js
@@ -85,6 +85,10 @@
 				}, this);
 			}
 
+			if (typeof this.options.geocoderResult == 'function') {
+				this.options.autocompleteOptions.geocoderResult = this.options.geocoderResult;
+			}
+
 			new Autocomplete(geocoderInput, function(r) {
 					geocoderInput.value = r.name;
 					wp.name = r.name;


### PR DESCRIPTION
This PR adds a `geocoderResult` option which allows you to pass a function to customize the HTML that is used in the results list. If the option is not provided it will default to the current HTML (a single text node).

The original motivation for this was to strip the country name from the results, but this allows you to customize however you wish. For example:

```
    geocoderResult: (result) => {
      let container = L.DomUtil.create('div');
      let address = L.DomUtil.create('div', 'address', container);
      let region = L.DomUtil.create('div', 'region', container);

      let make = (el, key) => {
        let span = L.DomUtil.create('span', key);
        let text = result.properties[key];

        if (text == undefined || text == '') {
          return;
        }

        span.appendChild(document.createTextNode(text));
        el.appendChild(span);
      };

      ['address', 'text'].map(key => make(address, key));
      ['place', 'region', 'postcode'].map(key => make(region, key));

      return container;
    }
  })
```

Before:
![pr-before](https://user-images.githubusercontent.com/199674/44497036-1b8d4f00-a645-11e8-9d73-07054e887815.png)

After:
![pr-after](https://user-images.githubusercontent.com/199674/44497043-221bc680-a645-11e8-881d-fa87f29380e8.png)

