### PR TITLE
Prevent default Action when pressing ENTER in Autocompletion Mode

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -124,6 +124,7 @@
 			}
 
 			if (e.keyCode === 13) {
+				L.DomEvent.preventDefault(e);
 				this._complete(this._resultFn, true);
 				return;
 			}


### PR DESCRIPTION
This serves to prevent accidentally submitting an enclosing form