### PR TITLE
Show the return error message instead of undefined when OSRMv1 HTTP r…

### DIFF
--- a/src/osrm-v1.js
+++ b/src/osrm-v1.js
@@ -104,8 +104,16 @@
 							error.message = 'Error parsing OSRM response: ' + ex.toString();
 						}
 					} else {
-						error.message = 'HTTP request failed: ' + err.type +
-							(err.target && err.target.status ? ' HTTP ' + err.target.status + ': ' + err.target.statusText : '');
+						var message = err.type + (err.target && err.target.status ? ' HTTP ' + err.target.status + ': ' + err.target.statusText : '');
+						if (err.responseText) {
+							try {
+								data = JSON.parse(err.responseText);
+								if (data.message)
+									message = data.message;
+							} catch (ex) {
+							}
+						}
+						error.message = 'HTTP request failed: ' + message;
 						error.url = url;
 						error.status = -1;
 						error.target = err;


### PR DESCRIPTION
…equest failed

With this patch, error message shown goes from:
`HTTP request failed: undefined`
to:
`HTTP request failed: Too Many Requests`

Fix bug  #510 