### PR TITLE
Firefox 64 now supports thin scrollbars

### DIFF
--- a/dist/leaflet-routing-machine.css
+++ b/dist/leaflet-routing-machine.css
@@ -59,6 +59,10 @@
     cursor: pointer;
 }
 
+.leaflet-routing-alt {
+    scrollbar-width: thin;
+}
+
 .leaflet-routing-alt::-webkit-scrollbar {
     width: 8px;
 }


### PR DESCRIPTION
Since firefox 64, thin scrollbars are supported thanks to the new scrollbar-width property.