### PR TITLE
Change broken url to OSM tiles

### DIFF
--- a/tutorials/basic-usage/index.html
+++ b/tutorials/basic-usage/index.html
@@ -81,7 +81,7 @@ title: Basics tutorial
 
 <pre class="line-numbers"><code class="language-javascript">var map = L.map('map');
 
-L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}{r}.png', {
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
 }).addTo(map);
 


### PR DESCRIPTION
The url in the example will never work as there is no resolution in the official OpenStreetMap tiles urls.