### PR TITLE
Fix about name of waypoints

### DIFF
--- a/src/plan.js
+++ b/src/plan.js
@@ -248,7 +248,7 @@
 				}, this),
 				dragEnd = L.bind(function(e) {
 					this._waypoints[i].latLng = eventLatLng(e);
-					this._waypoints[i].name = '';
+					this._waypoints[i].name ||= '';
 					if (this._geocoderElems) {
 						this._geocoderElems[i].update(true);
 					}


### PR DESCRIPTION
Ensure assign name of waypoint with empty string only if the original name has no value.