### PR TITLE
Trip option addition

### DIFF
--- a/src/line.js
+++ b/src/line.js
@@ -122,7 +122,7 @@
 
 		_getWaypointIndices: function() {
 			if (!this._wpIndices) {
-				this._wpIndices = this._route.waypointIndices || this._findWaypointIndices();
+				this._wpIndices = this._findWaypointIndices();
 			}
 
 			return this._wpIndices;


### PR DESCRIPTION
This pull request is intended to extend leaflet_routing_machine with the implementation of the trip service. Trip service is an alternative to regular routing which returns an optimised route (TSP algorithm)  to connect all waypoints.
Documentation and parameters of trip service are explained in http://project-osrm.org/docs/v5.22.0/api/#trip-service
These are the modifications applied:
Changes in osrm-v1.js:
Lines 21-35:
        Add new properties to control if the service calls the trip (optimised) or routing urls
        tripOptions: properties for the options available in trip service
Line 73 : Assign the end-point url depending on optimised.
Lines 169-185: Parse and trip service response format
Lines 365-379: Build end-point url with the appropriate parameters depending on routing/trip

Changes in line.js
Line 125: When optimise=true the result doesn´t need to follow the order of the entry coordinates. With this change we force the process to recalculate the indices of the entry waypoints in the response coordinates.