### PR TITLE
Fix maps and routing on Github Pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,7 @@
     <link rel="stylesheet" href="{{site.baseurl}}/public/css/site.css" />
     <script src="https://unpkg.com/leaflet@latest/dist/leaflet-src.js"></script>
     <script src="https://unpkg.com/leaflet.icon.glyph@0.2.0/Leaflet.Icon.Glyph.js"></script>
-    <script src="{{site.baseurl}}/lib/Control.Geocoder.js"></script>
+    <script src="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.js"></script>
     <script src="https://unpkg.com/leaflet-routing-machine@latest/dist/leaflet-routing-machine.js"></script>
   </head>
   <body>

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -22,12 +22,12 @@
     <link rel="stylesheet" href="{{site.baseurl}}/lib/prism.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.1/dist/leaflet.css" />
     <link rel="stylesheet" href="{{site.baseurl}}/lib/leaflet.iconlabel.css" />
-    <link rel="stylesheet" href="{{site.baseurl}}/dist/leaflet-routing-machine.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet-routing-machine@latest/dist/leaflet-routing-machine.css" />
     <link rel="stylesheet" href="{{site.baseurl}}/public/css/site.css" />
-    <script src="https://unpkg.com/leaflet@1.0.1/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@latest/dist/leaflet-src.js"></script>
     <script src="{{site.baseurl}}/lib/leaflet.iconlabel.js"></script>
-    <script src="{{site.baseurl}}/lib/Control.Geocoder.js"></script>
-    <script src="{{site.baseurl}}/dist/leaflet-routing-machine.js"></script>
+    <script src="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.js"></script>
+    <script src="https://unpkg.com/leaflet-routing-machine@latest/dist/leaflet-routing-machine.js"></script>
     <script src="{{site.baseurl}}/config.js"></script>
   </head>
   <body>

--- a/config.js
+++ b/config.js
@@ -1,15 +1,17 @@
 /*
  * Hi there,
  * Please, PLEASE do not re-use this token in your own projects or anywhere else.
- * I personally pay out of my own pocket for my Mapbox account, and do it to make a nice demo for
+ * This is a free tier token on openrouteservice.org that has limited quota as is. It is solely meant as a demo token for
  * Leaflet Routing Machine, not to fund other projects.
  *
- * Please get your own Mapbox account if you like their maps, it's not that expensive.
+ * Please get your own OpenRouteService account if you like their services, it's not that expensive.
  * I and the other contributors to Leaflet Routing Machine give it and its source away for free,
  * stealing this key from me to save a few bucks feels a bit cheap, to be honest.
  */
 window.LRM = {
-	apiToken: 'pk.eyJ1IjoibGllZG1hbiIsImEiOiJjazIwZGZvOXkwemQ5M211Z3B3c2M5bmpvIn0.Q8TUG4ornnhqO9ApeU3ZUQ'
+	osmServiceUrl: 'https://routing.openstreetmap.de/routed-car/route/v1',
+	orsServiceUrl: 'https://api.openrouteservice.org/geocode/',
+	apiToken: '5b3ce3597851110001cf6248ff41dc332def43858dff1ecccdd19bbc'
 };
 
 console.log("                    ___\n                _.-'   ```'--.._                 _____ ___ ___   ____  _____ __ __      ______  __ __    ___  \n              .'                `-._            / ___/|   |   | /    |/ ___/|  |  |    |      ||  |  |  /  _] \n             /                      `.         (   \\_ | _   _ ||  o  (   \\_ |  |  |    |      ||  |  | /  [_        \n            /                         `.        \\__  ||  \\_/  ||     |\\__  ||  _  |    |_|  |_||  _  ||    _]       \n           /                            `.      /  \\ ||   |   ||  _  |/  \\ ||  |  |      |  |  |  |  ||   [_        \n          :       (                       \\     \\    ||   |   ||  |  |\\    ||  |  |      |  |  |  |  ||     |       \n          |    (   \\_                  )   `.    \\___||___|___||__|__| \\___||__|__|      |__|  |__|__||_____|       \n          |     \\__/ '.               /  )  ;  \n          |   (___:    \\            _/__/   ;    ____   ____  ______  ____   ____   ____  ____      __  __ __  __ __ \n          :       | _  ;          .'   |__) :   |    \\ /    ||      ||    \\ |    | /    ||    \\    /  ]|  |  ||  |  |\n           :      |` \\ |         /     /   /    |  o  )  o  ||      ||  D  ) |  | |  o  ||  D  )  /  / |  |  ||  |  |\n            \\     |_  ;|        /`\\   /   /     |   _/|     ||_|  |_||    /  |  | |     ||    /  /  /  |  _  ||  ~  |\n             \\    ; ) :|       ;_  ; /   /      |  |  |  _  |  |  |  |    \\  |  | |  _  ||    \\ /   \\_ |  |  ||___, |\n              \\_  .-''-.       | ) :/   /       |  |  |  |  |  |  |  |  .  \\ |  | |  |  ||  .  \\\\     ||  |  ||     |\n             .-         `      .--.'   /        |__|  |__|__|  |__|  |__|\\_||____||__|__||__|\\_| \\____||__|__||____/ \n            :         _.----._     `  < \n            :       -'........'-       `.\n             `.        `''''`           ;\n               `'-.__                  ,'\n                     ``--.   :'-------'\n                         :   :\n                        .'   '.\n      \n      \n                                                                    ");

--- a/config.js
+++ b/config.js
@@ -9,6 +9,7 @@
  * stealing this key from me to save a few bucks feels a bit cheap, to be honest.
  */
 window.LRM = {
+	tileLayerUrl: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 	osmServiceUrl: 'https://routing.openstreetmap.de/routed-car/route/v1',
 	orsServiceUrl: 'https://api.openrouteservice.org/geocode/',
 	apiToken: '5b3ce3597851110001cf6248ff41dc332def43858dff1ecccdd19bbc'

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 
 var control = L.Routing.control({
 		router: L.routing.osrmv1({
-			serviceUrl: 'https://routing.openstreetmap.de/routed-car/route/v1'
+			serviceUrl: LRM.osmServiceUrl
 		}),
 		plan: L.Routing.plan(waypoints, {
 			createMarker: function(i, wp) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var map = L.map('map', { scrollWheelZoom: false }),
 		L.latLng(52.3546,4.9039)
 	];
 
-L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+L.tileLayer(LRM.tileLayerUrl, {
 	attribution: 'Maps and routes from <a href="https://www.openstreetmap.org">OpenStreetMap</a>. ' +
 		'data uses <a href="http://opendatacommons.org/licenses/odbl/">ODbL</a> license'
 }).addTo(map);

--- a/index.js
+++ b/index.js
@@ -4,14 +4,15 @@ var map = L.map('map', { scrollWheelZoom: false }),
 		L.latLng(52.3546,4.9039)
 	];
 
-L.tileLayer('https://a.tiles.mapbox.com/v4/mapbox.streets/{z}/{x}/{y}{r}.png?access_token=' + LRM.apiToken, {
-	attribution: 'Maps by <a href="https://www.mapbox.com/about/maps/">MapBox</a>. ' +
-		'Routes from <a href="http://project-osrm.org/">OSRM</a>, ' +
+L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	attribution: 'Maps and routes from <a href="https://www.openstreetmap.org">OpenStreetMap</a>. ' +
 		'data uses <a href="http://opendatacommons.org/licenses/odbl/">ODbL</a> license'
 }).addTo(map);
 
 var control = L.Routing.control({
-		router: L.routing.mapbox(LRM.apiToken),
+		router: L.routing.osrmv1({
+			serviceUrl: 'https://routing.openstreetmap.de/routed-car/route/v1'
+		}),
 		plan: L.Routing.plan(waypoints, {
 			createMarker: function(i, wp) {
 				return L.marker(wp.latLng, {

--- a/tutorials/basic-usage/index.js
+++ b/tutorials/basic-usage/index.js
@@ -1,6 +1,6 @@
 var map = L.map('map', { scrollWheelZoom: false });
 
-L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+L.tileLayer(LRM.tileLayerUrl, {
     attribution: 'Maps and routes from <a href="https://www.openstreetmap.org">OpenStreetMap</a>. ' +
         'data uses <a href="http://opendatacommons.org/licenses/odbl/">ODbL</a> license'
 }).addTo(map);

--- a/tutorials/basic-usage/index.js
+++ b/tutorials/basic-usage/index.js
@@ -1,13 +1,14 @@
 var map = L.map('map', { scrollWheelZoom: false });
 
-L.tileLayer('https://a.tiles.mapbox.com/v4/mapbox.streets/{z}/{x}/{y}{r}.png?access_token=' + LRM.apiToken, {
-    attribution: 'Maps by <a href="https://www.mapbox.com/about/maps/">MapBox</a>. ' +
-        'Routes from <a href="http://project-osrm.org/">OSRM</a>, ' +
+L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: 'Maps and routes from <a href="https://www.openstreetmap.org">OpenStreetMap</a>. ' +
         'data uses <a href="http://opendatacommons.org/licenses/odbl/">ODbL</a> license'
 }).addTo(map);
 
 var control = L.Routing.control({
-        router: L.routing.mapbox(LRM.apiToken),
+        router: L.routing.osrmv1({
+			serviceUrl: LRM.osmServiceUrl
+		}),
         waypoints: [
             L.latLng(57.74, 11.94),
             L.latLng(57.6792, 11.949)

--- a/tutorials/geocoders/index.js
+++ b/tutorials/geocoders/index.js
@@ -1,6 +1,6 @@
 var map1 = L.map('map-1', { scrollWheelZoom: false });
 
-L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+L.tileLayer(LRM.tileLayerUrl, {
     attribution: 'Maps and routes from <a href="https://www.openstreetmap.org">OpenStreetMap</a>. ' +
         'data uses <a href="http://opendatacommons.org/licenses/odbl/">ODbL</a> license'
 }).addTo(map1);
@@ -29,7 +29,7 @@ var control1 = L.Routing.control({
 
 var map2 = L.map('map-2', { scrollWheelZoom: false });
 
-L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+L.tileLayer(LRM.tileLayerUrl, {
     attribution: 'Maps and routes from <a href="https://www.openstreetmap.org">OpenStreetMap</a>. ' +
         'Geocoding by <a href="https://openrouteservice.org">OpenRouteService</a>' +
         'data uses <a href="http://opendatacommons.org/licenses/odbl/">ODbL</a> license'

--- a/tutorials/geocoders/index.js
+++ b/tutorials/geocoders/index.js
@@ -1,13 +1,14 @@
 var map1 = L.map('map-1', { scrollWheelZoom: false });
 
-L.tileLayer('https://a.tiles.mapbox.com/v4/mapbox.streets/{z}/{x}/{y}{r}.png?access_token=' + LRM.apiToken, {
-    attribution: 'Maps by <a href="https://www.mapbox.com/about/maps/">MapBox</a>. ' +
-        'Routes from <a href="http://project-osrm.org/">OSRM</a>, ' +
+L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: 'Maps and routes from <a href="https://www.openstreetmap.org">OpenStreetMap</a>. ' +
         'data uses <a href="http://opendatacommons.org/licenses/odbl/">ODbL</a> license'
 }).addTo(map1);
 
 var control1 = L.Routing.control({
-        router: L.routing.mapbox(LRM.apiToken),
+        router: L.routing.osrmv1({
+			serviceUrl: 'https://routing.openstreetmap.de/routed-car/route/v1'
+		}),
         waypoints: [
             L.latLng(57.74, 11.94),
             L.latLng(57.6792, 11.949)
@@ -28,20 +29,25 @@ var control1 = L.Routing.control({
 
 var map2 = L.map('map-2', { scrollWheelZoom: false });
 
-L.tileLayer('https://a.tiles.mapbox.com/v4/mapbox.streets/{z}/{x}/{y}{r}.png?access_token=' + LRM.apiToken, {
-    attribution: 'Maps by <a href="https://www.mapbox.com/about/maps/">MapBox</a>. ' +
-        'Routes from <a href="http://project-osrm.org/">OSRM</a>, ' +
+L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: 'Maps and routes from <a href="https://www.openstreetmap.org">OpenStreetMap</a>. ' +
+        'Geocoding by <a href="https://openrouteservice.org">OpenRouteService</a>' +
         'data uses <a href="http://opendatacommons.org/licenses/odbl/">ODbL</a> license'
 }).addTo(map2);
 
 var control2 = L.Routing.control({
-        router: L.routing.mapbox(LRM.apiToken),
+        router: L.routing.osrmv1({
+			serviceUrl: LRM.osmServiceUrl
+		}),
         waypoints: [
             L.latLng(37.76, -122.45),
             L.latLng(38.12, -122.22)
         ],
         routeWhileDragging: true,
-        geocoder: L.Control.Geocoder.mapbox(LRM.apiToken),
+        geocoder: L.Control.Geocoder.openrouteservice({
+            serviceUrl: LRM.orsServiceUrl,
+            apiKey: LRM.apiToken
+        }),
         waypointNameFallback: function(latLng) {
             function zeroPad(n) {
                 n = Math.round(n);

--- a/tutorials/integration/index.js
+++ b/tutorials/integration/index.js
@@ -1,6 +1,6 @@
 var map = L.map('map-1', { scrollWheelZoom: false });
 
-L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+L.tileLayer(LRM.tileLayerUrl, {
     attribution: 'Maps and routes from <a href="https://www.openstreetmap.org">OpenStreetMap</a>. ' +
         'data uses <a href="http://opendatacommons.org/licenses/odbl/">ODbL</a> license'
 }).addTo(map);

--- a/tutorials/integration/index.js
+++ b/tutorials/integration/index.js
@@ -1,13 +1,14 @@
 var map = L.map('map-1', { scrollWheelZoom: false });
 
-L.tileLayer('https://a.tiles.mapbox.com/v4/mapbox.streets/{z}/{x}/{y}{r}.png?access_token=' + LRM.apiToken, {
-    attribution: 'Maps by <a href="https://www.mapbox.com/about/maps/">MapBox</a>. ' +
-        'Routes from <a href="http://project-osrm.org/">OSRM</a>, ' +
+L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: 'Maps and routes from <a href="https://www.openstreetmap.org">OpenStreetMap</a>. ' +
         'data uses <a href="http://opendatacommons.org/licenses/odbl/">ODbL</a> license'
 }).addTo(map);
 
 var control = L.Routing.control({
-        router: L.routing.mapbox(LRM.apiToken),
+        router: L.routing.osrmv1({
+			serviceUrl: LRM.osmServiceUrl
+		}),
         waypoints: [
             L.latLng(57.74, 11.94),
             L.latLng(57.6792, 11.949)

--- a/tutorials/interaction/index.js
+++ b/tutorials/interaction/index.js
@@ -1,6 +1,6 @@
 var map1 = L.map('map-1', { scrollWheelZoom: false });
 
-L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+L.tileLayer(LRM.tileLayerUrl, {
     attribution: 'Maps and routes from <a href="https://www.openstreetmap.org">OpenStreetMap</a>. ' +
         'data uses <a href="http://opendatacommons.org/licenses/odbl/">ODbL</a> license'
 }).addTo(map1);

--- a/tutorials/interaction/index.js
+++ b/tutorials/interaction/index.js
@@ -1,8 +1,7 @@
 var map1 = L.map('map-1', { scrollWheelZoom: false });
 
-L.tileLayer('https://a.tiles.mapbox.com/v4/mapbox.streets/{z}/{x}/{y}{r}.png?access_token=' + LRM.apiToken, {
-    attribution: 'Maps by <a href="https://www.mapbox.com/about/maps/">MapBox</a>. ' +
-        'Routes from <a href="http://project-osrm.org/">OSRM</a>, ' +
+L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: 'Maps and routes from <a href="https://www.openstreetmap.org">OpenStreetMap</a>. ' +
         'data uses <a href="http://opendatacommons.org/licenses/odbl/">ODbL</a> license'
 }).addTo(map1);
 
@@ -14,7 +13,9 @@ function button(label, container) {
 }
 
 var control = L.Routing.control({
-        router: L.routing.mapbox(LRM.apiToken),
+        router: L.routing.osrmv1({
+			serviceUrl: LRM.osmServiceUrl
+		}),
         routeWhileDragging: true,
         plan: new (L.Routing.Plan.extend({
             createGeocoders: function() {


### PR DESCRIPTION
This fixes the map layer and LRM initialization on the Github pages site over at https://www.liedman.net/leaflet-routing-machine/ by replacing mapbox with OSM.

The one instance that needs autocomplete has been replaced with OpenRouteService which provides a free tier. Since it's now no longer needed, I removed the Mapbox API key as well