### PR TITLE
Updating Nominatim url to reflect API changes 

### DIFF
--- a/examples/Control.Geocoder.js
+++ b/examples/Control.Geocoder.js
@@ -338,7 +338,7 @@
 		},
 
 		geocode: function(query, cb, context) {
-			L.Control.Geocoder.jsonp(this.options.serviceUrl + 'search/', L.extend({
+			L.Control.Geocoder.jsonp(this.options.serviceUrl + 'search', L.extend({
 				q: query,
 				limit: 5,
 				format: 'json',
@@ -365,7 +365,7 @@
 		},
 
 		reverse: function(location, scale, cb, context) {
-			L.Control.Geocoder.jsonp(this.options.serviceUrl + 'reverse/', L.extend({
+			L.Control.Geocoder.jsonp(this.options.serviceUrl + 'reverse', L.extend({
 				lat: location.lat,
 				lon: location.lng,
 				zoom: Math.round(Math.log(scale / 256) / Math.log(2)),


### PR DESCRIPTION
The Nominatim geocoder stoped working. 

resulted in a `404 Not Found` response: File Not Found
File not found: API no longer accessible via this URL

Here is the Nominatim service response for given url:

File not found: API no longer accessible via this URL Using the URL /search/ and /reverse/ (with slashes) is no longer supported. Please use URLs as given in the documentation.

Examples how to change the URL:

You use: https://nominatim.openstreetmap.org/search/?q=Berlin
Change to: https://nominatim.openstreetmap.org/search?q=Berlin

You use: https://nominatim.openstreetmap.org/search/US/Texas/Huston
Change to: https://nominatim.openstreetmap.org/search?q=Huston, Texas, US