### PR TITLE
prevent undefined previous waypoint on dragNewWaypoint

### DIFF
--- a/src/plan.js
+++ b/src/plan.js
@@ -291,6 +291,7 @@
 		},
 
 		_dragNewWaypoint: function(newWpIndex, initialLatLng) {
+			newWpIndex = (newWpIndex === 0) ? 1 : newWpIndex;
 			var wp = new Waypoint(initialLatLng),
 				prevWp = this._waypoints[newWpIndex - 1],
 				nextWp = this._waypoints[newWpIndex],


### PR DESCRIPTION
Fixes #589 by ensuring `newWPIndex` is not set to 0. If so, change to 1 to ensure `prevWP` can be set. Found this issue tends to appear when a route loops and has the same start and finish location.