### PR TITLE
Fix two issues related to event propagation

### DIFF
--- a/src/geocoder-element.js
+++ b/src/geocoder-element.js
@@ -80,7 +80,8 @@
 			}, geocoderInput);
 
 			if (closeButton) {
-				L.DomEvent.addListener(closeButton, 'click', function() {
+				L.DomEvent.addListener(closeButton, 'click', function(e) {
+					L.DomEvent.stopPropagation(e);
 					this.fire('delete', { waypoint: this._waypoint });
 				}, this);
 			}

--- a/src/itinerary.js
+++ b/src/itinerary.js
@@ -53,7 +53,7 @@
 			this._altContainer = this.createAlternativesContainer();
 			this._container.appendChild(this._altContainer);
 			L.DomEvent.disableClickPropagation(this._container);
-			L.DomEvent.addListener(this._container, 'mousewheel', function(e) {
+			L.DomEvent.addListener(this._container, 'mousewheel wheel', function(e) {
 				L.DomEvent.stopPropagation(e);
 			});
 


### PR DESCRIPTION
There currently are two issues caused by event propagation:
* Clicking on the close button in the way point list moves or places the start or end marker to/at the position of the close button.
* Trying to scroll the itinerary in Firefox results in zooming of the map in the background instead of scrolling the itinerary.

This should get fixed by this PR.